### PR TITLE
Update github.md

### DIFF
--- a/docs/github.md
+++ b/docs/github.md
@@ -321,7 +321,7 @@ Desarrollado por Sergio Gómez.
 
 Como mensaje del _commit_: _'Indicado que se realiza en el ASL'_.
 
-Y ahora probamos a actualizar con `git push`:
+Y ahora probamos a actualizar con `git pull`:
 
 ```
 $ git pull


### PR DESCRIPTION
Se corrige una errata en el apartado de 'git pull' que ponía usar el comando 'git push' cuando debería ser 'pull'